### PR TITLE
Don't leak memory forever

### DIFF
--- a/js/stupidcat.js
+++ b/js/stupidcat.js
@@ -21,6 +21,11 @@ function stupidcat() {
 	var thisSlap = slap.cloneNode(true);
 	thisSlap.volume = 0.2;
 	thisSlap.play();
+	thisSlap.addEventListener("progress", function() {
+		if (thisSlap.ended) {
+			thisSlap.src = undefined;
+		}
+	});
 	localStorage["slapcount"] = slapcountint;
 	updatescore();
 }


### PR DESCRIPTION
If an HTMLAudioElement could potentially be played, it cannot be GC'd even if no references to it exist. Setting src=undefined means it can't potentially be played ever